### PR TITLE
pin theme pack plugin to only patch upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@greenwood/cli": "~0.15.2",
     "@greenwood/plugin-graphql": "~0.15.2",
     "@greenwood/plugin-import-css": "~0.15.2",
-    "greenwood-starter-presentation": "^0.3.0",
+    "greenwood-starter-presentation": "~0.3.0",
     "rimraf": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,10 +1859,10 @@ gray-matter@^2.1.0:
     js-yaml "^3.8.1"
     toml "^2.3.2"
 
-greenwood-starter-presentation@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/greenwood-starter-presentation/-/greenwood-starter-presentation-0.3.0.tgz#8a274837c4647c3a40bb09767c7403ad2523c639"
-  integrity sha512-DQWXORsn+Nb1902d9zoF/K1BMRZDBM+318KXOFXZlroxe44ItJP3fi834AAd0EcXhd8s8d1fYsRqnWU/+osFLw==
+greenwood-starter-presentation@~0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/greenwood-starter-presentation/-/greenwood-starter-presentation-0.3.1.tgz#408b955094d7f1d14a1f7386b26376fc8ffd61d7"
+  integrity sha512-+iDRsbEeEgG/2c74boEe7z/XkmVpKczmCmSLioBIV5ltAnRQ1ljrzGjWj7GJRMPQEoI6Fy4m5Yj5ArXl3nWBrQ==
   dependencies:
     lit-element "^2.4.0"
 


### PR DESCRIPTION
This way the plugin can iterate with newer minor versions and not break existing installs.